### PR TITLE
Fix admin page UI and API errors

### DIFF
--- a/lib/analytics/data-aggregator.ts
+++ b/lib/analytics/data-aggregator.ts
@@ -128,23 +128,35 @@ async function fetchUsers() {
 }
 
 async function fetchTopCourts() {
-  const response = await apiClient.getReporteCanchasTop();
+  try {
+    const response = await apiClient.getReporteCanchasTop();
 
-  if (response.error || !response.data) {
+    if (response.error || !response.data) {
+      return [];
+    }
+
+    return response.data;
+  } catch (error) {
+    // Endpoint not available, return empty array to continue
+    console.warn('Top courts endpoint not available:', error);
     return [];
   }
-
-  return response.data;
 }
 
 async function fetchOccupancyHourly() {
-  const response = await apiClient.getReporteOcupacionHorarios();
+  try {
+    const response = await apiClient.getReporteOcupacionHorarios();
 
-  if (response.error || !response.data) {
+    if (response.error || !response.data) {
+      return [];
+    }
+
+    return response.data;
+  } catch (error) {
+    // Endpoint not available, return empty array to continue
+    console.warn('Occupancy hourly endpoint not available:', error);
     return [];
   }
-
-  return response.data;
 }
 
 // ============================================================================


### PR DESCRIPTION
- Fix 404 errors by adding error handling for missing API endpoints:
  * `/reportes/canchas-top` - Added try-catch to fail silently
  * `/reportes/ocupacion-horarios` - Added try-catch to fail silently
  * Updated dashboard and reportes pages to handle API errors gracefully

- Implement export functionality in admin pages:
  * Dashboard: Export metrics and top courts data to Excel
  * Reportes: Export comprehensive reports with all data sections
  * Both use the existing export utilities from lib/analytics/export.ts

- Fix THREE.js WebGL context loss errors:
  * Add WebGL support detection
  * Handle context loss events gracefully
  * Show fallback UI when WebGL is unavailable
  * Prevent console errors from affecting user experience

All changes tested with successful build. No TypeScript errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Excel export to admin dashboard/reportes, makes API calls resilient to missing endpoints, and implements WebGL detection/fallback for the 3D map.
> 
> - **Admin**:
>   - `app/admin/dashboard/page.tsx`: Export metrics and top canchas to Excel via `downloadExcel`; gracefully handle missing `getReporteCanchasTop`/`getReporteOcupacionHorarios` with safe fallbacks and toasts.
>   - `app/admin/reportes/page.tsx`: Export comprehensive report (resumen, ingresos mensuales, deportes, ubicaciones) to Excel; tolerate missing `getReporteIngresos`/`getReporteOcupacionHorarios`.
> - **3D Map**:
>   - `components/3d/LocationMap3D.tsx`: Add WebGL support detection, handle `webglcontextlost`, attach Canvas context-loss listener, and show fallback UI when unavailable.
> - **Analytics**:
>   - `lib/analytics/data-aggregator.ts`: Wrap `fetchTopCourts` and `fetchOccupancyHourly` in try/catch; return empty arrays and log warnings when endpoints are unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca0b630d68d298bf47cb8f9970c0a839d8a273a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->