### PR TITLE
Update charts when filtering by date period

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -680,6 +680,7 @@ export default function DashboardPage() {
             loading={loading}
             onClubClick={handleClubClick}
             onCanchaClick={handleCanchaClick}
+            filters={activeFilters}
           />
         </div>
       </div>


### PR DESCRIPTION
This commit ensures that when users apply filters (periodo, cancha, deporte, or date range) in the dashboard, all charts including the ClubAnalyticsCard update to display the filtered data.

Changes:
- Updated ClubAnalyticsCard to accept filters prop
- Added filter logic to ClubAnalyticsCard data fetching
- ClubAnalyticsCard now re-fetches data when filters change
- Used useCallback to properly handle React Hook dependencies
- Passed activeFilters from dashboard page to ClubAnalyticsCard

All charts (OccupancyChart, CanchaDistributionChart, HeatMap, TopCanchasTable, and ClubAnalyticsCard) now synchronize with the global filter state.