### PR TITLE
Analyze club field and day data

### DIFF
--- a/components/admin/dashboard/ClubAnalyticsCard.tsx
+++ b/components/admin/dashboard/ClubAnalyticsCard.tsx
@@ -21,6 +21,7 @@ import {
 import apiClient from '@/lib/api-client'
 import { toast } from 'sonner'
 import type { Club, Cancha, Reserva } from '@/lib/api-client'
+import { formatCompactNumber } from '@/lib/analytics/formatters'
 
 interface ClubStats {
   id: string
@@ -283,7 +284,7 @@ export function ClubAnalyticsCard({
                         <div>
                           <p className="text-xs text-gray-500">Ingresos</p>
                           <p className="text-lg font-bold text-green-600">
-                            ${club.ingresos.toLocaleString()}
+                            ${formatCompactNumber(club.ingresos)}
                           </p>
                         </div>
                       </div>
@@ -362,7 +363,7 @@ export function ClubAnalyticsCard({
                                 {cancha.deporte.nombre}
                               </Badge>
                               <span className="text-xs text-gray-500">
-                                ${cancha.precioPorHora}/hora
+                                ${formatCompactNumber(cancha.precioPorHora)}/h
                               </span>
                             </div>
                           </div>

--- a/components/admin/dashboard/DrillDownModal.tsx
+++ b/components/admin/dashboard/DrillDownModal.tsx
@@ -50,6 +50,7 @@ import { es } from 'date-fns/locale'
 import apiClient, { type Reserva } from '@/lib/api-client'
 import { toast } from 'sonner'
 import { downloadCSV } from '@/lib/analytics/export'
+import { formatCompactNumber } from '@/lib/analytics/formatters'
 
 export type DrillDownType = 'cancha' | 'club' | 'hora' | 'dia' | 'deporte'
 
@@ -363,7 +364,7 @@ export function DrillDownModal({ isOpen, onClose, data }: DrillDownModalProps) {
                   </CardHeader>
                   <CardContent>
                     <div className="text-2xl font-bold text-green-600">
-                      ${analytics.summary.ingresoTotal.toLocaleString()}
+                      ${formatCompactNumber(analytics.summary.ingresoTotal)}
                     </div>
                     <p className="text-xs text-gray-500 mt-1">
                       Total generado
@@ -407,7 +408,14 @@ export function DrillDownModal({ isOpen, onClose, data }: DrillDownModalProps) {
                       <CartesianGrid strokeDasharray="3 3" />
                       <XAxis dataKey="dia" />
                       <YAxis />
-                      <Tooltip />
+                      <Tooltip
+                        formatter={(value: any, name: string) => {
+                          if (name === 'Ingresos ($)') {
+                            return `$${formatCompactNumber(Number(value))}`
+                          }
+                          return value
+                        }}
+                      />
                       <Legend />
                       <Bar dataKey="cantidad" name="Reservas" fill="#3b82f6" />
                       <Bar dataKey="ingresos" name="Ingresos ($)" fill="#10b981" />
@@ -452,8 +460,10 @@ export function DrillDownModal({ isOpen, onClose, data }: DrillDownModalProps) {
                     <BarChart data={analytics.revenueByPeriod}>
                       <CartesianGrid strokeDasharray="3 3" />
                       <XAxis dataKey="periodo" />
-                      <YAxis />
-                      <Tooltip />
+                      <YAxis tickFormatter={(value) => `$${formatCompactNumber(value)}`} />
+                      <Tooltip
+                        formatter={(value: any) => `$${formatCompactNumber(Number(value))}`}
+                      />
                       <Bar dataKey="ingresos" name="Ingresos" fill="#10b981" />
                     </BarChart>
                   </ResponsiveContainer>
@@ -488,7 +498,7 @@ export function DrillDownModal({ isOpen, onClose, data }: DrillDownModalProps) {
                           <TableCell className="font-medium">{user.usuario}</TableCell>
                           <TableCell className="text-right">{user.reservas}</TableCell>
                           <TableCell className="text-right font-semibold text-green-600">
-                            ${user.gastTotal.toLocaleString()}
+                            ${formatCompactNumber(user.gastTotal)}
                           </TableCell>
                         </TableRow>
                       ))}


### PR DESCRIPTION
- Use formatCompactNumber for large currency values (displays as 1.2K, 10.5M)
- Apply consistent formatting to revenue displays in ClubAnalyticsCard
- Format prices per hour more compactly ($/h instead of $/hora)
- Add custom tooltip formatters in DrillDownModal charts
- Format user spending totals consistently
- Apply compact formatting to Y-axis labels in revenue charts

This makes the dashboard more readable by avoiding very long numbers and providing consistent, clean number displays across all analysis views.