### PR TITLE
Fix string addition and chart display bugs

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -164,7 +164,7 @@ const fetchDashboardData = async (filters?: Record<string, any> | null): Promise
     // Calculate revenue (sum of all completed reservations)
     const totalRevenue = confirmedReservations.reduce((sum, r) => {
       const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-      const price = cancha?.precioPorHora || 0
+      const price = Number(cancha?.precioPorHora || 0)
       return sum + (isNaN(price) ? 0 : price)
     }, 0)
 
@@ -230,7 +230,7 @@ const fetchDashboardData = async (filters?: Record<string, any> | null): Promise
       })
       const dayRevenue = dayReservations.reduce((sum, r) => {
         const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-        return sum + (cancha?.precioPorHora || 0)
+        return sum + Number(cancha?.precioPorHora || 0)
       }, 0)
       return {
         date: format(date, 'dd MMM', { locale: es }),
@@ -282,7 +282,7 @@ const fetchDashboardData = async (filters?: Record<string, any> | null): Promise
           heatMapData.push({
             day,
             hour,
-            occupancy: ocupacion?.ocupacion || 0
+            occupancy: Number(ocupacion?.ocupacion || 0)
           })
         }
       }
@@ -312,7 +312,7 @@ const fetchDashboardData = async (filters?: Record<string, any> | null): Promise
             name: data.name,
             sport: data.sport,
             reservations: data.count,
-            revenue: data.count * (cancha?.precioPorHora || 0),
+            revenue: data.count * Number(cancha?.precioPorHora || 0),
             occupancy: Math.round((data.count / 30) * 100),
             trend: Math.random() > 0.5 ? Math.floor(Math.random() * 10) : -Math.floor(Math.random() * 5)
           }
@@ -323,8 +323,8 @@ const fetchDashboardData = async (filters?: Record<string, any> | null): Promise
             name: entry.canchaNombre,
             sport: cancha?.deporte.nombre || 'Desconocido',
             reservations: entry.cantidadReservas,
-            revenue: entry.cantidadReservas * (cancha?.precioPorHora || 0),
-            occupancy: Math.round((entry.cantidadReservas / 30) * 100),
+            revenue: Number(entry.cantidadReservas || 0) * Number(cancha?.precioPorHora || 0),
+            occupancy: Math.round((Number(entry.cantidadReservas || 0) / 30) * 100),
             trend: Math.random() > 0.5 ? Math.floor(Math.random() * 10) : -Math.floor(Math.random() * 5)
           }
         }

--- a/app/admin/reportes/page.tsx
+++ b/app/admin/reportes/page.tsx
@@ -114,7 +114,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
     // Calculate total revenue
     const totalRevenue = confirmedReservations.reduce((sum, r) => {
       const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-      return sum + (cancha?.precioPorHora || 0)
+      return sum + Number(cancha?.precioPorHora || 0)
     }, 0)
 
     // Calculate occupancy rate
@@ -134,7 +134,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
 
       const revenue = monthReservations.reduce((sum, r) => {
         const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-        return sum + (cancha?.precioPorHora || 0)
+        return sum + Number(cancha?.precioPorHora || 0)
       }, 0)
 
       return {
@@ -156,7 +156,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
 
       const revenue = dayReservations.reduce((sum, r) => {
         const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-        return sum + (cancha?.precioPorHora || 0)
+        return sum + Number(cancha?.precioPorHora || 0)
       }, 0)
 
       return {
@@ -170,7 +170,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
     const hourlyRevenueData = ocupacionHorarios.length > 0
       ? ocupacionHorarios.slice(0, 8).map(o => ({
           hour: o.hora,
-          revenue: o.ocupacion * 100 // Simplified revenue calculation
+          revenue: Number(o.ocupacion || 0) * 100 // Simplified revenue calculation
         }))
       : Array.from({ length: 8 }, (_, i) => {
           const hour = 8 + i * 2
@@ -180,7 +180,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
           })
           const revenue = hourReservations.reduce((sum, r) => {
             const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-            return sum + (cancha?.precioPorHora || 0)
+            return sum + Number(cancha?.precioPorHora || 0)
           }, 0)
           return { hour: `${hour}:00`, revenue }
         })
@@ -192,7 +192,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
       if (cancha) {
         const sportName = cancha.deporte.nombre
         const existing = sportMap.get(sportName)
-        const revenue = cancha.precioPorHora || 0
+        const revenue = Number(cancha.precioPorHora || 0)
         if (existing) {
           existing.count++
           existing.revenue += revenue
@@ -221,7 +221,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
           return {
             location: item.clubNombre,
             reservations: 0, // Not provided by API
-            revenue: item.ingresoTotal,
+            revenue: Number(item.ingresoTotal || 0),
             growth: Math.random() > 0.5 ? Math.random() * 20 : -Math.random() * 10
           }
         } else {
@@ -232,7 +232,7 @@ const fetchReportData = async (period: string): Promise<ReportData> => {
           )
           const clubRevenue = clubReservations.reduce((sum, r) => {
             const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-            return sum + (cancha?.precioPorHora || 0)
+            return sum + Number(cancha?.precioPorHora || 0)
           }, 0)
           return {
             location: item.nombre,

--- a/components/admin/dashboard/ClubAnalyticsCard.tsx
+++ b/components/admin/dashboard/ClubAnalyticsCard.tsx
@@ -140,7 +140,7 @@ export function ClubAnalyticsCard({
 
         const ingresos = confirmedReservas.reduce((sum: number, r: Reserva) => {
           const cancha = clubCanchasData.find((c: Cancha) => c.id === r.disponibilidad?.cancha?.id)
-          return sum + (cancha?.precioPorHora || 0)
+          return sum + Number(cancha?.precioPorHora || 0)
         }, 0)
 
         const deportes = Array.from(new Set(clubCanchasData.map((c: Cancha) => c.deporte.nombre)))
@@ -363,7 +363,7 @@ export function ClubAnalyticsCard({
                                 {cancha.deporte.nombre}
                               </Badge>
                               <span className="text-xs text-gray-500">
-                                ${formatCompactNumber(cancha.precioPorHora)}/h
+                                ${formatCompactNumber(Number(cancha.precioPorHora || 0))}/h
                               </span>
                             </div>
                           </div>

--- a/components/admin/dashboard/DrillDownModal.tsx
+++ b/components/admin/dashboard/DrillDownModal.tsx
@@ -172,7 +172,7 @@ export function DrillDownModal({ isOpen, onClose, data }: DrillDownModalProps) {
 
       const totalRevenue = confirmedReservations.reduce((sum, r) => {
         const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-        return sum + (cancha?.precioPorHora || 0)
+        return sum + Number(cancha?.precioPorHora || 0)
       }, 0)
 
       // Hourly distribution
@@ -193,7 +193,7 @@ export function DrillDownModal({ isOpen, onClose, data }: DrillDownModalProps) {
         const day = new Date(r.fechaHora).getDay()
         const existing = dailyMap.get(day) || { cantidad: 0, ingresos: 0 }
         const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-        const revenue = cancha?.precioPorHora || 0
+        const revenue = Number(cancha?.precioPorHora || 0)
         dailyMap.set(day, {
           cantidad: existing.cantidad + 1,
           ingresos: existing.ingresos + revenue
@@ -212,7 +212,7 @@ export function DrillDownModal({ isOpen, onClose, data }: DrillDownModalProps) {
         const userName = r.persona.nombre
         const existing = userMap.get(userId) || { reservas: 0, gasto: 0 }
         const cancha = canchas.find(c => c.id === r.disponibilidad?.cancha?.id)
-        const cost = cancha?.precioPorHora || 0
+        const cost = Number(cancha?.precioPorHora || 0)
         userMap.set(userName, {
           reservas: existing.reservas + 1,
           gasto: existing.gasto + cost

--- a/components/analytics/UserSegmentation.tsx
+++ b/components/analytics/UserSegmentation.tsx
@@ -14,8 +14,8 @@ interface UserSegmentationProps {
 }
 
 export function UserSegmentation({ segmentData, className }: UserSegmentationProps) {
-  const totalUsers = segmentData.reduce((sum, s) => sum + s.count, 0);
-  const totalRevenue = segmentData.reduce((sum, s) => sum + s.revenue, 0);
+  const totalUsers = segmentData.reduce((sum, s) => sum + Number(s.count || 0), 0);
+  const totalRevenue = segmentData.reduce((sum, s) => sum + Number(s.revenue || 0), 0);
 
   // Prepare chart data
   const chartData = segmentData.map(s => ({
@@ -294,7 +294,7 @@ function generateRecommendations(segmentData: UserSegmentData[]): string[] {
 
   // VIP recommendations
   if (vipSegment && vipSegment.count > 0) {
-    const vipRevenue = (vipSegment.revenue / segmentData.reduce((sum, s) => sum + s.revenue, 0)) * 100;
+    const vipRevenue = (Number(vipSegment.revenue || 0) / segmentData.reduce((sum, s) => sum + Number(s.revenue || 0), 0)) * 100;
     recommendations.push(
       `🌟 Usuarios VIP representan ${formatPercentage(vipRevenue, 1)} de los ingresos con solo ${formatPercentage(vipSegment.percentage, 1)} de usuarios. Implementar programa de beneficios exclusivos para retenerlos.`
     );

--- a/components/dashboard/featured-courts.tsx
+++ b/components/dashboard/featured-courts.tsx
@@ -228,7 +228,7 @@ export default function FeaturedCourts() {
                 v => v.tipo_objetivo === 'cancha' && v.id_objetivo === court.id
               )
               if (courtVals.length > 0) {
-                const avg = courtVals.reduce((sum, v) => sum + v.puntaje, 0) / courtVals.length
+                const avg = courtVals.reduce((sum, v) => sum + Number(v.puntaje || 0), 0) / courtVals.length
                 ratings[court.id] = avg
               } else {
                 ratings[court.id] = 4.5 // Default rating

--- a/components/dashboard/hero-section.tsx
+++ b/components/dashboard/hero-section.tsx
@@ -76,7 +76,7 @@ export default function HeroSection() {
         // Calculate average rating from valoraciones
         let averageRating = 4.9
         if (valoracionesResponse.data && valoracionesResponse.data.length > 0) {
-          const totalRating = valoracionesResponse.data.reduce((sum, val) => sum + val.puntaje, 0)
+          const totalRating = valoracionesResponse.data.reduce((sum, val) => sum + Number(val.puntaje || 0), 0)
           averageRating = Number((totalRating / valoracionesResponse.data.length).toFixed(1))
         }
 

--- a/lib/analytics/data-aggregator.ts
+++ b/lib/analytics/data-aggregator.ts
@@ -205,7 +205,7 @@ function calculateMetrics(
 
   // FINANCIAL METRICS
   const payments = reservations.map(r => ({
-    monto: r.precio || 0,
+    monto: Number(r.precio || 0),
     estado: r.estado === 'CONFIRMADA' ? 'PAGADO' : 'PENDIENTE'
   }));
 
@@ -215,9 +215,9 @@ function calculateMetrics(
 
   const pendingPayments = payments
     .filter(p => p.estado === 'PENDIENTE')
-    .reduce((sum, p) => sum + p.monto, 0);
+    .reduce((sum, p) => sum + Number(p.monto || 0), 0);
 
-  const expectedRevenue = payments.reduce((sum, p) => sum + p.monto, 0);
+  const expectedRevenue = payments.reduce((sum, p) => sum + Number(p.monto || 0), 0);
 
   const delinquencyRate = calculateDelinquencyRate(pendingPayments, expectedRevenue);
   const collectionRate = calculateCollectionRate(totalRevenue, expectedRevenue);
@@ -564,7 +564,7 @@ async function fetchUsersTrend(start: Date, end: Date): Promise<TimeSeriesData[]
 function processTopCourts(topCourtsData: any[], reservations: any[]): CourtPerformance[] {
   return topCourtsData.slice(0, 5).map(court => {
     const courtReservations = reservations.filter(r => r.canchaId === court.id);
-    const revenue = courtReservations.reduce((sum, r) => sum + (r.precio || 0), 0);
+    const revenue = courtReservations.reduce((sum, r) => sum + Number(r.precio || 0), 0);
 
     return {
       id: court.id,

--- a/lib/analytics/kpi-calculator.ts
+++ b/lib/analytics/kpi-calculator.ts
@@ -67,7 +67,7 @@ export function calculateAverageReservationsPerDay(
 export function calculateTotalRevenue(payments: Array<{ monto: number; estado: string }>): number {
   return payments
     .filter(p => p.estado === 'PAGADO')
-    .reduce((sum, p) => sum + p.monto, 0);
+    .reduce((sum, p) => sum + Number(p.monto || 0), 0);
 }
 
 /**
@@ -136,7 +136,7 @@ export function calculateAverageFrequency(
 ): number {
   if (userReservations.length === 0) return 0;
 
-  const totalReservations = userReservations.reduce((sum, u) => sum + u.count, 0);
+  const totalReservations = userReservations.reduce((sum, u) => sum + Number(u.count || 0), 0);
   return totalReservations / userReservations.length;
 }
 
@@ -213,7 +213,7 @@ export function determineStatus(
  */
 export function calculateMean(values: number[]): number {
   if (values.length === 0) return 0;
-  return values.reduce((sum, val) => sum + val, 0) / values.length;
+  return values.reduce((sum, val) => sum + Number(val || 0), 0) / values.length;
 }
 
 /**


### PR DESCRIPTION
…oard components

This commit addresses critical issues where numeric values from the backend were being treated as strings, causing incorrect calculations in charts and totals. All reduce operations now properly convert values to numbers before performing mathematical operations.

Changes:
- app/admin/reportes/page.tsx: Convert precioPorHora, ocupacion, ingresoTotal to numbers
- app/admin/dashboard/page.tsx: Convert precioPorHora, ocupacion, cantidadReservas to numbers
- components/admin/dashboard/ClubAnalyticsCard.tsx: Convert precioPorHora to number
- components/admin/dashboard/DrillDownModal.tsx: Convert precioPorHora to number in all calculations
- components/analytics/UserSegmentation.tsx: Convert count and revenue to numbers
- components/dashboard/featured-courts.tsx: Convert puntaje to number
- components/dashboard/hero-section.tsx: Convert puntaje to number
- lib/analytics/data-aggregator.ts: Convert precio and monto to numbers
- lib/analytics/kpi-calculator.ts: Convert monto, count, and all numeric values to numbers

This ensures all charts (pie, bar, line) display correct numeric values and all financial calculations produce accurate results.