### PR TITLE
Implement Challenges API module with endpoints

### DIFF
--- a/app/(dashboard)/desafios/page.tsx
+++ b/app/(dashboard)/desafios/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next'
+import ChallengesList from '@/components/challenges/challenges-list'
+
+export const metadata: Metadata = {
+  title: 'Desafíos | CanchaYA',
+  description: 'Gestiona tus desafíos deportivos y competiciones',
+}
+
+export default function DesafiosPage() {
+  return (
+    <div className="container mx-auto py-8">
+      <ChallengesList />
+    </div>
+  )
+}

--- a/components/challenges/add-players-dialog.tsx
+++ b/components/challenges/add-players-dialog.tsx
@@ -1,0 +1,246 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { toast } from 'sonner'
+import apiClient, { Desafio, Persona } from '@/lib/api-client'
+import { Search, UserPlus, X } from 'lucide-react'
+
+interface AddPlayersDialogProps {
+  challenge: Desafio
+  canAddCreadores: boolean
+  canAddDesafiados: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function AddPlayersDialog({
+  challenge,
+  canAddCreadores,
+  canAddDesafiados,
+  onClose,
+  onSuccess,
+}: AddPlayersDialogProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<Persona[]>([])
+  const [selectedPlayers, setSelectedPlayers] = useState<Persona[]>([])
+  const [selectedSide, setSelectedSide] = useState<'creador' | 'desafiado'>(
+    canAddCreadores ? 'creador' : 'desafiado'
+  )
+  const [isSearching, setIsSearching] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Debounced search
+  useEffect(() => {
+    if (searchQuery.length < 2) {
+      setSearchResults([])
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      setIsSearching(true)
+      try {
+        const response = await apiClient.searchPersonas(searchQuery)
+        if (response.error) {
+          toast.error(response.error)
+          return
+        }
+
+        if (response.data) {
+          // Filter out players already in the challenge
+          const allPlayers = [
+            ...challenge.jugadoresCreador,
+            ...challenge.jugadoresDesafiados,
+            ...challenge.invitadosDesafiados,
+          ]
+          const filtered = response.data.filter(
+            p => !allPlayers.some(existing => existing.id === p.id) &&
+                 !selectedPlayers.some(selected => selected.id === p.id)
+          )
+          setSearchResults(filtered)
+        }
+      } catch (error) {
+        console.error('Error searching personas:', error)
+        toast.error('Error al buscar jugadores')
+      } finally {
+        setIsSearching(false)
+      }
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [searchQuery, challenge, selectedPlayers])
+
+  const handleAddPlayer = (player: Persona) => {
+    setSelectedPlayers(prev => [...prev, player])
+    setSearchResults(prev => prev.filter(p => p.id !== player.id))
+    setSearchQuery('')
+  }
+
+  const handleRemovePlayer = (playerId: string) => {
+    setSelectedPlayers(prev => prev.filter(p => p.id !== playerId))
+  }
+
+  const handleSubmit = async () => {
+    if (selectedPlayers.length === 0) {
+      toast.error('Debes seleccionar al menos un jugador')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const response = await apiClient.agregarJugadoresDesafio(challenge.id, {
+        lado: selectedSide,
+        jugadoresIds: selectedPlayers.map(p => p.id),
+      })
+
+      if (response.error) {
+        toast.error(response.error)
+        return
+      }
+
+      toast.success('Jugadores agregados exitosamente')
+      onSuccess()
+    } catch (error) {
+      console.error('Error adding players:', error)
+      toast.error('No se pudieron agregar los jugadores')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Agregar jugadores</DialogTitle>
+          <DialogDescription>
+            Busca y agrega compañeros a tu equipo
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Side selector if user can add to both sides */}
+          {canAddCreadores && canAddDesafiados && (
+            <div className="space-y-2">
+              <Label>Agregar a equipo</Label>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant={selectedSide === 'creador' ? 'default' : 'outline'}
+                  onClick={() => setSelectedSide('creador')}
+                  className="flex-1"
+                >
+                  Equipo Creador
+                </Button>
+                <Button
+                  type="button"
+                  variant={selectedSide === 'desafiado' ? 'default' : 'outline'}
+                  onClick={() => setSelectedSide('desafiado')}
+                  className="flex-1"
+                >
+                  Equipo Desafiado
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Single side display */}
+          {!(canAddCreadores && canAddDesafiados) && (
+            <div className="space-y-2">
+              <Label>Agregar a equipo</Label>
+              <Badge variant="outline">
+                {selectedSide === 'creador' ? 'Equipo Creador' : 'Equipo Desafiado'}
+              </Badge>
+            </div>
+          )}
+
+          {/* Search input */}
+          <div className="space-y-2">
+            <Label htmlFor="search">Buscar jugadores</Label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                id="search"
+                placeholder="Nombre, apellido o email..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+          </div>
+
+          {/* Search results */}
+          {searchResults.length > 0 && (
+            <div className="space-y-2 max-h-[200px] overflow-y-auto border rounded-lg p-2">
+              {searchResults.map(person => (
+                <div
+                  key={person.id}
+                  className="flex items-center justify-between p-2 hover:bg-muted rounded cursor-pointer"
+                  onClick={() => handleAddPlayer(person)}
+                >
+                  <div>
+                    <div className="font-medium text-sm">
+                      {person.nombre} {person.apellido}
+                    </div>
+                    <div className="text-xs text-muted-foreground">{person.email}</div>
+                  </div>
+                  <Button size="sm" variant="ghost">
+                    <UserPlus className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {isSearching && (
+            <div className="text-sm text-muted-foreground text-center">
+              Buscando...
+            </div>
+          )}
+
+          {/* Selected players */}
+          {selectedPlayers.length > 0 && (
+            <div className="space-y-2">
+              <Label>Jugadores seleccionados ({selectedPlayers.length})</Label>
+              <div className="space-y-1">
+                {selectedPlayers.map(player => (
+                  <div
+                    key={player.id}
+                    className="flex items-center justify-between p-2 bg-muted rounded"
+                  >
+                    <div className="text-sm">
+                      {player.nombre} {player.apellido}
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => handleRemovePlayer(player.id)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={selectedPlayers.length === 0 || isSubmitting}
+          >
+            {isSubmitting ? 'Agregando...' : `Agregar ${selectedPlayers.length} jugador${selectedPlayers.length !== 1 ? 'es' : ''}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/challenges/challenge-card.tsx
+++ b/components/challenges/challenge-card.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Calendar, Clock, MapPin, Users, Trophy, Star } from 'lucide-react'
+import { Desafio } from '@/lib/api-client'
+import { formatDate, formatTime } from '@/lib/date-utils'
+import { useState } from 'react'
+import { AddPlayersDialog } from './add-players-dialog'
+import { FinalizeChallengeDialog } from './finalize-challenge-dialog'
+
+interface ChallengeCardProps {
+  challenge: Desafio
+  currentPersonaId: string
+  onAccept: (id: string) => Promise<void>
+  onReject: (id: string) => Promise<void>
+  onUpdate: () => void
+}
+
+export function ChallengeCard({
+  challenge,
+  currentPersonaId,
+  onAccept,
+  onReject,
+  onUpdate,
+}: ChallengeCardProps) {
+  const [showAddPlayers, setShowAddPlayers] = useState(false)
+  const [showFinalize, setShowFinalize] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Check user role in this challenge
+  const isCreator = challenge.creador.id === currentPersonaId
+  const isInvited = challenge.invitadosDesafiados.some(p => p.id === currentPersonaId)
+  const isJugadorCreador = challenge.jugadoresCreador.some(p => p.id === currentPersonaId)
+  const isJugadorDesafiado = challenge.jugadoresDesafiados.some(p => p.id === currentPersonaId)
+  const isParticipant = isCreator || isJugadorCreador || isJugadorDesafiado
+
+  // Check if reservation is in the past
+  const reservationDate = new Date(challenge.reserva.fechaHora)
+  const isPast = reservationDate < new Date()
+
+  // Determine which side can add players
+  const canAddCreadores = isCreator || isJugadorCreador
+  const canAddDesafiados = isJugadorDesafiado
+
+  // Can finalize if:
+  // - User is a participant
+  // - Estado is 'Aceptado'
+  // - Reservation is in the past
+  const canFinalize = isParticipant && challenge.estado === 'Aceptado' && isPast
+
+  const getEstadoBadge = (estado: Desafio['estado']) => {
+    switch (estado) {
+      case 'Pendiente':
+        return <Badge variant="outline" className="bg-yellow-100 text-yellow-800">Pendiente</Badge>
+      case 'Aceptado':
+        return <Badge variant="default" className="bg-green-100 text-green-800">Aceptado</Badge>
+      case 'Cancelado':
+        return <Badge variant="secondary" className="bg-gray-100 text-gray-800">Cancelado</Badge>
+      case 'Finalizado':
+        return <Badge variant="default" className="bg-blue-100 text-blue-800">Finalizado</Badge>
+      default:
+        return <Badge variant="outline">{estado}</Badge>
+    }
+  }
+
+  const handleAccept = async () => {
+    setIsLoading(true)
+    try {
+      await onAccept(challenge.id)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleReject = async () => {
+    setIsLoading(true)
+    try {
+      await onReject(challenge.id)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Card className="hover:shadow-lg transition-shadow">
+      <CardHeader>
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <Trophy className="h-5 w-5 text-yellow-600" />
+              {challenge.deporte.nombre}
+            </CardTitle>
+            <div className="text-sm text-muted-foreground mt-1">
+              Creado por {challenge.creador.nombre} {challenge.creador.apellido}
+            </div>
+          </div>
+          {getEstadoBadge(challenge.estado)}
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Reservation details */}
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <span>{formatDate(challenge.reserva.fechaHora)}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <Clock className="h-4 w-4 text-muted-foreground" />
+            <span>{formatTime(challenge.reserva.fechaHora)}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <MapPin className="h-4 w-4 text-muted-foreground" />
+            <span>{challenge.reserva.disponibilidad?.cancha?.nombre || 'Cancha'}</span>
+          </div>
+        </div>
+
+        {/* Teams */}
+        <div className="grid grid-cols-2 gap-4 pt-4 border-t">
+          {/* Team Creador */}
+          <div className="space-y-2">
+            <div className="font-semibold text-sm flex items-center gap-1">
+              <Users className="h-4 w-4" />
+              Equipo Creador
+            </div>
+            <div className="space-y-1">
+              {challenge.jugadoresCreador.map(jugador => (
+                <div key={jugador.id} className="text-sm">
+                  {jugador.nombre} {jugador.apellido}
+                  {jugador.id === challenge.creador.id && (
+                    <Badge variant="outline" className="ml-1 text-xs">Capitán</Badge>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Team Desafiado */}
+          <div className="space-y-2">
+            <div className="font-semibold text-sm flex items-center gap-1">
+              <Users className="h-4 w-4" />
+              Equipo Desafiado
+            </div>
+            <div className="space-y-1">
+              {/* Invited players */}
+              {challenge.invitadosDesafiados.map(invitado => (
+                <div key={invitado.id} className="text-sm text-muted-foreground italic">
+                  {invitado.nombre} {invitado.apellido} (invitado)
+                </div>
+              ))}
+              {/* Accepted players */}
+              {challenge.jugadoresDesafiados.map(jugador => (
+                <div key={jugador.id} className="text-sm">
+                  {jugador.nombre} {jugador.apellido}
+                </div>
+              ))}
+              {challenge.jugadoresDesafiados.length === 0 && challenge.invitadosDesafiados.length === 0 && (
+                <div className="text-sm text-muted-foreground">Sin jugadores</div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Result if finalized */}
+        {challenge.estado === 'Finalizado' && challenge.resultado && (
+          <div className="pt-4 border-t">
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-semibold">Resultado: {challenge.resultado}</div>
+              {challenge.ganadorLado && (
+                <Badge variant="default" className="bg-yellow-100 text-yellow-800">
+                  Ganador: {challenge.ganadorLado === 'creador' ? 'Equipo Creador' : 'Equipo Desafiado'}
+                </Badge>
+              )}
+            </div>
+            {(challenge.valoracionCreador || challenge.valoracionDesafiado) && (
+              <div className="flex items-center gap-4 mt-2 text-sm">
+                {challenge.valoracionCreador && (
+                  <div className="flex items-center gap-1">
+                    <Star className="h-4 w-4 text-yellow-500" />
+                    Creador: {challenge.valoracionCreador}/5
+                  </div>
+                )}
+                {challenge.valoracionDesafiado && (
+                  <div className="flex items-center gap-1">
+                    <Star className="h-4 w-4 text-yellow-500" />
+                    Desafiado: {challenge.valoracionDesafiado}/5
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Action buttons */}
+        <div className="flex flex-wrap gap-2 pt-4 border-t">
+          {/* Accept/Reject for invited players */}
+          {isInvited && !isPast && (
+            <>
+              <Button
+                size="sm"
+                onClick={handleAccept}
+                disabled={isLoading}
+              >
+                Aceptar desafío
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleReject}
+                disabled={isLoading}
+              >
+                Rechazar
+              </Button>
+            </>
+          )}
+
+          {/* Add players */}
+          {(canAddCreadores || canAddDesafiados) && (challenge.estado === 'Pendiente' || challenge.estado === 'Aceptado') && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setShowAddPlayers(true)}
+            >
+              Agregar compañeros
+            </Button>
+          )}
+
+          {/* Finalize */}
+          {canFinalize && (
+            <Button
+              size="sm"
+              onClick={() => setShowFinalize(true)}
+            >
+              Cargar resultado
+            </Button>
+          )}
+
+          {/* Info for past pending challenges */}
+          {isPast && challenge.estado === 'Pendiente' && (
+            <Badge variant="secondary" className="bg-gray-100 text-gray-600">
+              Desafío expirado
+            </Badge>
+          )}
+        </div>
+      </CardContent>
+
+      {/* Dialogs */}
+      {showAddPlayers && (
+        <AddPlayersDialog
+          challenge={challenge}
+          canAddCreadores={canAddCreadores}
+          canAddDesafiados={canAddDesafiados}
+          onClose={() => setShowAddPlayers(false)}
+          onSuccess={() => {
+            setShowAddPlayers(false)
+            onUpdate()
+          }}
+        />
+      )}
+
+      {showFinalize && (
+        <FinalizeChallengeDialog
+          challenge={challenge}
+          onClose={() => setShowFinalize(false)}
+          onSuccess={() => {
+            setShowFinalize(false)
+            onUpdate()
+          }}
+        />
+      )}
+    </Card>
+  )
+}

--- a/components/challenges/challenges-list.tsx
+++ b/components/challenges/challenges-list.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { toast } from 'sonner'
+import apiClient, { Desafio } from '@/lib/api-client'
+import { useAuth } from '@/components/auth/auth-context'
+import { ChallengeCard } from './challenge-card'
+import { CreateChallengeDialog } from './create-challenge-dialog'
+import { Trophy, Plus, Loader2 } from 'lucide-react'
+
+type ChallengeFilter = 'all' | 'created' | 'invited' | 'playing' | 'finalized'
+
+export default function ChallengesList() {
+  const { user } = useAuth()
+  const [challenges, setChallenges] = useState<Desafio[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [activeFilter, setActiveFilter] = useState<ChallengeFilter>('all')
+
+  useEffect(() => {
+    loadChallenges()
+  }, [])
+
+  const loadChallenges = async () => {
+    setIsLoading(true)
+    try {
+      const response = await apiClient.getDesafios()
+      if (response.error) {
+        toast.error(response.error)
+        return
+      }
+
+      if (response.data) {
+        // Sort by most recent first
+        const sorted = response.data.sort((a, b) => {
+          return new Date(b.creadoEl).getTime() - new Date(a.creadoEl).getTime()
+        })
+        setChallenges(sorted)
+      }
+    } catch (error) {
+      console.error('Error loading challenges:', error)
+      toast.error('No se pudieron cargar los desafíos')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleAcceptChallenge = async (challengeId: string) => {
+    try {
+      const response = await apiClient.aceptarDesafio(challengeId)
+      if (response.error) {
+        // Handle specific errors
+        if (response.error.includes('La reserva ya pasó')) {
+          toast.error('La reserva ya pasó, no se puede aceptar el desafío')
+        } else if (response.error.includes('ya había aceptado')) {
+          toast.error('Ya habías aceptado este desafío')
+        } else {
+          toast.error(response.error)
+        }
+        return
+      }
+
+      toast.success('Desafío aceptado exitosamente')
+      loadChallenges()
+    } catch (error) {
+      console.error('Error accepting challenge:', error)
+      toast.error('No se pudo aceptar el desafío')
+    }
+  }
+
+  const handleRejectChallenge = async (challengeId: string) => {
+    try {
+      const response = await apiClient.rechazarDesafio(challengeId)
+      if (response.error) {
+        toast.error(response.error)
+        return
+      }
+
+      toast.success('Desafío rechazado')
+      loadChallenges()
+    } catch (error) {
+      console.error('Error rejecting challenge:', error)
+      toast.error('No se pudo rechazar el desafío')
+    }
+  }
+
+  // Filter challenges based on active filter
+  const getFilteredChallenges = () => {
+    if (!user?.personaId) return []
+
+    const personaId = user.personaId
+
+    switch (activeFilter) {
+      case 'created':
+        // Challenges created by me
+        return challenges.filter(c => c.creador.id === personaId)
+
+      case 'invited':
+        // Challenges where I'm invited (in invitadosDesafiados)
+        return challenges.filter(c =>
+          c.invitadosDesafiados.some(p => p.id === personaId)
+        )
+
+      case 'playing':
+        // Challenges where I'm playing (in jugadoresCreador or jugadoresDesafiados)
+        return challenges.filter(c =>
+          c.jugadoresCreador.some(p => p.id === personaId) ||
+          c.jugadoresDesafiados.some(p => p.id === personaId)
+        )
+
+      case 'finalized':
+        // Finalized challenges where I participated
+        return challenges.filter(c =>
+          c.estado === 'Finalizado' &&
+          (c.creador.id === personaId ||
+           c.jugadoresCreador.some(p => p.id === personaId) ||
+           c.jugadoresDesafiados.some(p => p.id === personaId))
+        )
+
+      case 'all':
+      default:
+        // All challenges where I'm involved in any way
+        return challenges.filter(c =>
+          c.creador.id === personaId ||
+          c.jugadoresCreador.some(p => p.id === personaId) ||
+          c.jugadoresDesafiados.some(p => p.id === personaId) ||
+          c.invitadosDesafiados.some(p => p.id === personaId)
+        )
+    }
+  }
+
+  const filteredChallenges = getFilteredChallenges()
+
+  // Count challenges for each filter
+  const getCounts = () => {
+    if (!user?.personaId) return { all: 0, created: 0, invited: 0, playing: 0, finalized: 0 }
+
+    const personaId = user.personaId
+
+    return {
+      all: challenges.filter(c =>
+        c.creador.id === personaId ||
+        c.jugadoresCreador.some(p => p.id === personaId) ||
+        c.jugadoresDesafiados.some(p => p.id === personaId) ||
+        c.invitadosDesafiados.some(p => p.id === personaId)
+      ).length,
+      created: challenges.filter(c => c.creador.id === personaId).length,
+      invited: challenges.filter(c => c.invitadosDesafiados.some(p => p.id === personaId)).length,
+      playing: challenges.filter(c =>
+        c.jugadoresCreador.some(p => p.id === personaId) ||
+        c.jugadoresDesafiados.some(p => p.id === personaId)
+      ).length,
+      finalized: challenges.filter(c =>
+        c.estado === 'Finalizado' &&
+        (c.creador.id === personaId ||
+         c.jugadoresCreador.some(p => p.id === personaId) ||
+         c.jugadoresDesafiados.some(p => p.id === personaId))
+      ).length,
+    }
+  }
+
+  const counts = getCounts()
+
+  if (!user?.personaId) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Mis Desafíos</CardTitle>
+          <CardDescription>
+            Debes iniciar sesión para ver tus desafíos
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Trophy className="h-6 w-6 text-yellow-600" />
+                Mis Desafíos
+              </CardTitle>
+              <CardDescription>
+                Crea, acepta y gestiona tus desafíos deportivos
+              </CardDescription>
+            </div>
+            <Button onClick={() => setShowCreateDialog(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Nuevo desafío
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <Tabs value={activeFilter} onValueChange={(v) => setActiveFilter(v as ChallengeFilter)}>
+        <TabsList className="grid w-full grid-cols-5">
+          <TabsTrigger value="all">
+            Todos ({counts.all})
+          </TabsTrigger>
+          <TabsTrigger value="created">
+            Creados ({counts.created})
+          </TabsTrigger>
+          <TabsTrigger value="invited">
+            Invitaciones ({counts.invited})
+          </TabsTrigger>
+          <TabsTrigger value="playing">
+            Jugando ({counts.playing})
+          </TabsTrigger>
+          <TabsTrigger value="finalized">
+            Finalizados ({counts.finalized})
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value={activeFilter} className="mt-6">
+          {isLoading ? (
+            <Card>
+              <CardContent className="py-12">
+                <div className="flex flex-col items-center justify-center gap-4">
+                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                  <p className="text-muted-foreground">Cargando desafíos...</p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : filteredChallenges.length === 0 ? (
+            <Card>
+              <CardContent className="py-12">
+                <div className="flex flex-col items-center justify-center gap-4">
+                  <Trophy className="h-12 w-12 text-muted-foreground/50" />
+                  <div className="text-center">
+                    <p className="font-medium">No hay desafíos</p>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      {activeFilter === 'invited' && 'No tienes invitaciones pendientes'}
+                      {activeFilter === 'created' && 'Crea tu primer desafío'}
+                      {activeFilter === 'playing' && 'No estás jugando ningún desafío activo'}
+                      {activeFilter === 'finalized' && 'No tienes desafíos finalizados'}
+                      {activeFilter === 'all' && 'Crea tu primer desafío para comenzar'}
+                    </p>
+                  </div>
+                  {(activeFilter === 'created' || activeFilter === 'all') && (
+                    <Button onClick={() => setShowCreateDialog(true)} className="mt-4">
+                      <Plus className="h-4 w-4 mr-2" />
+                      Crear desafío
+                    </Button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-2">
+              {filteredChallenges.map(challenge => (
+                <ChallengeCard
+                  key={challenge.id}
+                  challenge={challenge}
+                  currentPersonaId={user.personaId}
+                  onAccept={handleAcceptChallenge}
+                  onReject={handleRejectChallenge}
+                  onUpdate={loadChallenges}
+                />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      {/* Create challenge dialog */}
+      <CreateChallengeDialog
+        open={showCreateDialog}
+        onClose={() => setShowCreateDialog(false)}
+        onSuccess={loadChallenges}
+      />
+    </div>
+  )
+}

--- a/components/challenges/create-challenge-dialog.tsx
+++ b/components/challenges/create-challenge-dialog.tsx
@@ -1,0 +1,441 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { toast } from 'sonner'
+import apiClient, { Reserva, Deporte, Persona } from '@/lib/api-client'
+import { Search, UserPlus, X, Calendar, MapPin } from 'lucide-react'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { formatDate, formatTime } from '@/lib/date-utils'
+
+interface CreateChallengeDialogProps {
+  open: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function CreateChallengeDialog({
+  open,
+  onClose,
+  onSuccess,
+}: CreateChallengeDialogProps) {
+  const [step, setStep] = useState(1)
+  const [reservas, setReservas] = useState<Reserva[]>([])
+  const [deportes, setDeportes] = useState<Deporte[]>([])
+  const [selectedReserva, setSelectedReserva] = useState<string>('')
+  const [selectedDeporte, setSelectedDeporte] = useState<string>('')
+  const [invitados, setInvitados] = useState<Persona[]>([])
+  const [compañeros, setCompañeros] = useState<Persona[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<Persona[]>([])
+  const [searchMode, setSearchMode] = useState<'invitados' | 'compañeros'>('invitados')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSearching, setIsSearching] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Load reservas and deportes on mount
+  useEffect(() => {
+    if (open) {
+      loadInitialData()
+    }
+  }, [open])
+
+  const loadInitialData = async () => {
+    setIsLoading(true)
+    try {
+      // Load user's reservas
+      const reservasResponse = await apiClient.getReservas()
+      if (reservasResponse.error) {
+        toast.error('Error al cargar reservas: ' + reservasResponse.error)
+      } else if (reservasResponse.data) {
+        // Filter: only future reservas, confirmed or pending
+        const futureReservas = reservasResponse.data.filter(r => {
+          const reservaDate = new Date(r.fechaHora)
+          return reservaDate > new Date() && (r.estado === 'confirmada' || r.estado === 'pendiente')
+        })
+        setReservas(futureReservas)
+      }
+
+      // Load deportes
+      const deportesResponse = await apiClient.getDeportes()
+      if (deportesResponse.error) {
+        toast.error('Error al cargar deportes: ' + deportesResponse.error)
+      } else if (deportesResponse.data) {
+        setDeportes(deportesResponse.data)
+      }
+    } catch (error) {
+      console.error('Error loading initial data:', error)
+      toast.error('Error al cargar datos')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // Debounced search
+  useEffect(() => {
+    if (searchQuery.length < 2) {
+      setSearchResults([])
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      setIsSearching(true)
+      try {
+        const response = await apiClient.searchPersonas(searchQuery)
+        if (response.error) {
+          toast.error(response.error)
+          return
+        }
+
+        if (response.data) {
+          // Filter out already selected players
+          const selectedIds = [
+            ...invitados.map(p => p.id),
+            ...compañeros.map(p => p.id),
+          ]
+          const filtered = response.data.filter(p => !selectedIds.includes(p.id))
+          setSearchResults(filtered)
+        }
+      } catch (error) {
+        console.error('Error searching personas:', error)
+        toast.error('Error al buscar jugadores')
+      } finally {
+        setIsSearching(false)
+      }
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [searchQuery, invitados, compañeros])
+
+  const handleAddPlayer = (player: Persona) => {
+    if (searchMode === 'invitados') {
+      setInvitados(prev => [...prev, player])
+    } else {
+      setCompañeros(prev => [...prev, player])
+    }
+    setSearchResults(prev => prev.filter(p => p.id !== player.id))
+    setSearchQuery('')
+  }
+
+  const handleRemoveInvitado = (playerId: string) => {
+    setInvitados(prev => prev.filter(p => p.id !== playerId))
+  }
+
+  const handleRemoveCompañero = (playerId: string) => {
+    setCompañeros(prev => prev.filter(p => p.id !== playerId))
+  }
+
+  const handleNext = () => {
+    if (step === 1) {
+      if (!selectedReserva) {
+        toast.error('Debes seleccionar una reserva')
+        return
+      }
+      if (!selectedDeporte) {
+        toast.error('Debes seleccionar un deporte')
+        return
+      }
+      setStep(2)
+    }
+  }
+
+  const handleBack = () => {
+    if (step === 2) {
+      setStep(1)
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (invitados.length === 0) {
+      toast.error('Debes invitar al menos un jugador')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const data = {
+        reservaId: selectedReserva,
+        deporteId: selectedDeporte,
+        invitadosDesafiadosIds: invitados.map(p => p.id),
+        jugadoresCreadorIds: compañeros.length > 0 ? compañeros.map(p => p.id) : undefined,
+      }
+
+      const response = await apiClient.createDesafio(data)
+
+      if (response.error) {
+        // Show specific error messages
+        if (response.error.includes('Ya hay un desafío')) {
+          toast.error('Ya existe un desafío para esta reserva')
+        } else if (response.error.includes('reserva pasada')) {
+          toast.error('No se puede crear un desafío con una reserva pasada')
+        } else {
+          toast.error(response.error)
+        }
+        return
+      }
+
+      toast.success('Desafío creado exitosamente')
+      onSuccess()
+      handleClose()
+    } catch (error) {
+      console.error('Error creating challenge:', error)
+      toast.error('No se pudo crear el desafío')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleClose = () => {
+    setStep(1)
+    setSelectedReserva('')
+    setSelectedDeporte('')
+    setInvitados([])
+    setCompañeros([])
+    setSearchQuery('')
+    setSearchResults([])
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Crear nuevo desafío</DialogTitle>
+          <DialogDescription>
+            {step === 1 ? 'Selecciona una reserva y deporte' : 'Invita jugadores a tu desafío'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="py-8 text-center text-muted-foreground">
+            Cargando...
+          </div>
+        ) : (
+          <>
+            {/* Step 1: Select reservation and sport */}
+            {step === 1 && (
+              <div className="space-y-4 py-4">
+                {/* Reservation selector */}
+                <div className="space-y-2">
+                  <Label>Selecciona una reserva</Label>
+                  {reservas.length === 0 ? (
+                    <div className="text-sm text-muted-foreground p-4 border rounded-lg text-center">
+                      No tienes reservas futuras disponibles.
+                      <br />
+                      <Button variant="link" asChild className="mt-2">
+                        <a href="/dashboard/reservations">Crear reserva</a>
+                      </Button>
+                    </div>
+                  ) : (
+                    <Select value={selectedReserva} onValueChange={setSelectedReserva}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Selecciona una reserva" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {reservas.map(reserva => (
+                          <SelectItem key={reserva.id} value={reserva.id}>
+                            <div className="flex items-center gap-2">
+                              <Calendar className="h-4 w-4" />
+                              {formatDate(reserva.fechaHora)} - {formatTime(reserva.fechaHora)}
+                              <MapPin className="h-4 w-4 ml-2" />
+                              {reserva.disponibilidad?.cancha?.nombre}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
+
+                {/* Sport selector */}
+                <div className="space-y-2">
+                  <Label>Selecciona el deporte</Label>
+                  {deportes.length === 0 ? (
+                    <div className="text-sm text-muted-foreground">
+                      No hay deportes disponibles
+                    </div>
+                  ) : (
+                    <Select value={selectedDeporte} onValueChange={setSelectedDeporte}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Selecciona un deporte" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {deportes.map(deporte => (
+                          <SelectItem key={deporte.id} value={deporte.id}>
+                            {deporte.nombre}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Step 2: Invite players */}
+            {step === 2 && (
+              <div className="space-y-4 py-4">
+                {/* Search mode selector */}
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant={searchMode === 'invitados' ? 'default' : 'outline'}
+                    onClick={() => setSearchMode('invitados')}
+                    className="flex-1"
+                  >
+                    Invitar rivales
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={searchMode === 'compañeros' ? 'default' : 'outline'}
+                    onClick={() => setSearchMode('compañeros')}
+                    className="flex-1"
+                  >
+                    Agregar compañeros
+                  </Button>
+                </div>
+
+                {/* Search input */}
+                <div className="space-y-2">
+                  <Label htmlFor="search">
+                    {searchMode === 'invitados' ? 'Buscar rivales' : 'Buscar compañeros'}
+                  </Label>
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      id="search"
+                      placeholder="Nombre, apellido o email..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      className="pl-9"
+                    />
+                  </div>
+                </div>
+
+                {/* Search results */}
+                {searchResults.length > 0 && (
+                  <div className="space-y-2 max-h-[200px] overflow-y-auto border rounded-lg p-2">
+                    {searchResults.map(person => (
+                      <div
+                        key={person.id}
+                        className="flex items-center justify-between p-2 hover:bg-muted rounded cursor-pointer"
+                        onClick={() => handleAddPlayer(person)}
+                      >
+                        <div>
+                          <div className="font-medium text-sm">
+                            {person.nombre} {person.apellido}
+                          </div>
+                          <div className="text-xs text-muted-foreground">{person.email}</div>
+                        </div>
+                        <Button size="sm" variant="ghost">
+                          <UserPlus className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {isSearching && (
+                  <div className="text-sm text-muted-foreground text-center">
+                    Buscando...
+                  </div>
+                )}
+
+                {/* Invited players */}
+                <div className="space-y-2">
+                  <Label>
+                    Rivales invitados ({invitados.length})
+                    {invitados.length === 0 && <span className="text-destructive ml-1">*</span>}
+                  </Label>
+                  {invitados.length === 0 ? (
+                    <div className="text-sm text-muted-foreground p-3 border rounded-lg text-center">
+                      Debes invitar al menos un rival
+                    </div>
+                  ) : (
+                    <div className="space-y-1">
+                      {invitados.map(player => (
+                        <div
+                          key={player.id}
+                          className="flex items-center justify-between p-2 bg-muted rounded"
+                        >
+                          <div className="text-sm">
+                            {player.nombre} {player.apellido}
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => handleRemoveInvitado(player.id)}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Teammates (optional) */}
+                {compañeros.length > 0 && (
+                  <div className="space-y-2">
+                    <Label>Compañeros de equipo ({compañeros.length})</Label>
+                    <div className="space-y-1">
+                      {compañeros.map(player => (
+                        <div
+                          key={player.id}
+                          className="flex items-center justify-between p-2 bg-muted rounded"
+                        >
+                          <div className="text-sm">
+                            {player.nombre} {player.apellido}
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => handleRemoveCompañero(player.id)}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+
+        <DialogFooter>
+          {step === 1 ? (
+            <>
+              <Button variant="outline" onClick={handleClose}>
+                Cancelar
+              </Button>
+              <Button
+                onClick={handleNext}
+                disabled={!selectedReserva || !selectedDeporte || isLoading}
+              >
+                Siguiente
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={handleBack} disabled={isSubmitting}>
+                Atrás
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={invitados.length === 0 || isSubmitting}
+              >
+                {isSubmitting ? 'Creando...' : 'Crear desafío'}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/challenges/finalize-challenge-dialog.tsx
+++ b/components/challenges/finalize-challenge-dialog.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { toast } from 'sonner'
+import apiClient, { Desafio } from '@/lib/api-client'
+import { Star, Trophy } from 'lucide-react'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+
+interface FinalizeChallengeDialogProps {
+  challenge: Desafio
+  onClose: () => void
+  onSuccess: () => void
+}
+
+export function FinalizeChallengeDialog({
+  challenge,
+  onClose,
+  onSuccess,
+}: FinalizeChallengeDialogProps) {
+  const [ganadorLado, setGanadorLado] = useState<'creador' | 'desafiado'>('creador')
+  const [resultado, setResultado] = useState('')
+  const [valoracion, setValoracion] = useState<number>(0)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async () => {
+    // Validate resultado format if provided
+    if (resultado) {
+      const regex = /^\d+-\d+$/
+      if (!regex.test(resultado)) {
+        toast.error('Formato de resultado inválido. Usa el formato "3-2"')
+        return
+      }
+    }
+
+    setIsSubmitting(true)
+    try {
+      const data: {
+        ganadorLado: 'creador' | 'desafiado'
+        resultado?: string
+        valoracion?: number
+      } = {
+        ganadorLado,
+      }
+
+      if (resultado) {
+        data.resultado = resultado
+      }
+
+      if (valoracion > 0) {
+        data.valoracion = valoracion
+      }
+
+      const response = await apiClient.finalizarDesafio(challenge.id, data)
+
+      if (response.error) {
+        // Check for specific error messages
+        if (response.error.includes('Aún no se puede finalizar')) {
+          toast.error('Aún no se puede finalizar: el partido no ha ocurrido')
+        } else if (response.error.includes('Formato de resultado inválido')) {
+          toast.error('Formato de resultado inválido. Usa el formato "3-2"')
+        } else {
+          toast.error(response.error)
+        }
+        return
+      }
+
+      toast.success('Desafío finalizado exitosamente. Rankings actualizados!')
+      onSuccess()
+    } catch (error) {
+      console.error('Error finalizing challenge:', error)
+      toast.error('No se pudo finalizar el desafío')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Trophy className="h-5 w-5 text-yellow-600" />
+            Cargar resultado del desafío
+          </DialogTitle>
+          <DialogDescription>
+            Registra el resultado del partido y actualiza los rankings
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          {/* Winner selection */}
+          <div className="space-y-3">
+            <Label>¿Qué equipo ganó?</Label>
+            <RadioGroup value={ganadorLado} onValueChange={(value) => setGanadorLado(value as 'creador' | 'desafiado')}>
+              <div className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted cursor-pointer">
+                <RadioGroupItem value="creador" id="creador" />
+                <Label htmlFor="creador" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Equipo Creador</div>
+                  <div className="text-sm text-muted-foreground">
+                    {challenge.jugadoresCreador.map(j => `${j.nombre} ${j.apellido}`).join(', ')}
+                  </div>
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted cursor-pointer">
+                <RadioGroupItem value="desafiado" id="desafiado" />
+                <Label htmlFor="desafiado" className="flex-1 cursor-pointer">
+                  <div className="font-medium">Equipo Desafiado</div>
+                  <div className="text-sm text-muted-foreground">
+                    {challenge.jugadoresDesafiados.length > 0
+                      ? challenge.jugadoresDesafiados.map(j => `${j.nombre} ${j.apellido}`).join(', ')
+                      : 'Sin jugadores'}
+                  </div>
+                </Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          {/* Score input */}
+          <div className="space-y-2">
+            <Label htmlFor="resultado">
+              Resultado (opcional)
+            </Label>
+            <Input
+              id="resultado"
+              placeholder="Ej: 3-2"
+              value={resultado}
+              onChange={(e) => setResultado(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Formato: golesCreador-golesDesafiado (ej: 3-2)
+            </p>
+          </div>
+
+          {/* Rating */}
+          <div className="space-y-3">
+            <Label>Valoración del partido (opcional)</Label>
+            <div className="flex gap-2">
+              {[1, 2, 3, 4, 5].map((rating) => (
+                <button
+                  key={rating}
+                  type="button"
+                  onClick={() => setValoracion(rating)}
+                  className="transition-colors"
+                >
+                  <Star
+                    className={`h-8 w-8 ${
+                      rating <= valoracion
+                        ? 'fill-yellow-400 text-yellow-400'
+                        : 'text-gray-300'
+                    }`}
+                  />
+                </button>
+              ))}
+            </div>
+            {valoracion > 0 && (
+              <p className="text-sm text-muted-foreground">
+                {valoracion} de 5 estrellas
+              </p>
+            )}
+          </div>
+
+          {/* Info message */}
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm">
+            <p className="font-medium text-blue-900">Qué sucederá:</p>
+            <ul className="list-disc list-inside text-blue-700 space-y-1 mt-1">
+              <li>Se actualizarán los rankings ELO de todos los jugadores</li>
+              <li>Se registrarán las estadísticas del partido</li>
+              <li>Se guardarán goles, victorias y rachas</li>
+              <li>Se notificará a todos los participantes</li>
+            </ul>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? 'Finalizando...' : 'Finalizar desafío'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/challenges/index.ts
+++ b/components/challenges/index.ts
@@ -1,0 +1,5 @@
+export { ChallengeCard } from './challenge-card'
+export { AddPlayersDialog } from './add-players-dialog'
+export { FinalizeChallengeDialog } from './finalize-challenge-dialog'
+export { CreateChallengeDialog } from './create-challenge-dialog'
+export { default as ChallengesList } from './challenges-list'

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -29,6 +29,7 @@ export default function Navbar() {
     { href: '/buscar', label: 'Buscar', icon: Search },
     { href: '/mis-reservas', label: t('nav.reservations'), icon: Calendar },
     ...(isAuthenticated ? [
+      { href: '/desafios', label: 'Desafíos', icon: Trophy },
       { href: '/profile', label: t('nav.profile'), icon: User }
     ] : []),
     ...(isAdmin ? [{ href: '/admin', label: t('nav.admin'), icon: Shield }] : []),
@@ -140,6 +141,12 @@ export default function Navbar() {
                       <Link href="/mis-reservas" className="flex items-center p-3 rounded-lg hover:bg-muted cursor-pointer">
                         <Calendar className="mr-3 h-5 w-5" />
                         <span className="font-medium">{t('nav.reservations')}</span>
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="/desafios" className="flex items-center p-3 rounded-lg hover:bg-muted cursor-pointer">
+                        <Trophy className="mr-3 h-5 w-5" />
+                        <span className="font-medium">Desafíos</span>
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>


### PR DESCRIPTION
This commit adds full frontend integration for the Desafíos (Challenges) module, implementing all API endpoints and user flows as specified in the backend API contract.

### API Client Updates:
- Updated Desafio interface to match backend structure with estado, ganadorLado, resultado
- Added DTOs: CrearDesafioDto, AgregarJugadoresDto, FinalizarDesafioDto
- Updated all Desafíos endpoints (create, accept, reject, add players, finalize)
- Added perfil-competitivo PATCH endpoint for activating/deactivating profiles
- Confirmed personas search endpoint exists

### UI Components:
- ChallengeCard: Displays challenge details, teams, reservation info, and action buttons
- CreateChallengeDialog: Two-step wizard for creating challenges (select reservation/sport, invite players)
- AddPlayersDialog: Search and add teammates or rivals to existing challenges
- FinalizeChallengeDialog: Record match results, winner, score, and rating
- ChallengesList: Main component with filters (all, created, invited, playing, finalized)

### Features Implemented:
- Create challenge based on existing reservation
- Invite players to challenges
- Accept/reject challenge invitations
- Add teammates to either team
- Finalize challenges with results and ratings
- Real-time challenge state management
- Client-side filtering by user role
- ELO and stats updates on finalization
- Comprehensive error handling with user-friendly messages

### Navigation:
- Added "Desafíos" link to navbar (desktop and mobile)
- Added desafios page at /desafios route
- Integrated with existing auth system

All implementations follow the backend API contract exactly as specified, including validations, error messages, and business logic requirements.